### PR TITLE
Add Valkey/Redis cluster support via Cloud Memorystore

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,21 +178,28 @@ No modules.
 | [google_project_iam_member.app_logging_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.app_monitoring_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.required_apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_redis_instance.valkey](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance) | resource |
 | [google_secret_manager_secret.ai_api_keys](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret.config_files](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret.db_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret.db_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret.mcp_api_keys](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret.valkey_auth](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret.valkey_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret_iam_member.app_ai_api_keys](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_iam_member.app_config_files](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_iam_member.app_db_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_iam_member.app_db_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_iam_member.app_mcp_api_keys](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.app_valkey_auth](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.app_valkey_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_version.ai_api_keys](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [google_secret_manager_secret_version.config_files](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [google_secret_manager_secret_version.db_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [google_secret_manager_secret_version.db_password](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [google_secret_manager_secret_version.mcp_api_keys](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
+| [google_secret_manager_secret_version.valkey_auth](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
+| [google_secret_manager_secret_version.valkey_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [google_service_account.app](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_networking_connection.private_vpc_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
 | [google_sql_database.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database) | resource |
@@ -233,6 +240,7 @@ No modules.
 | <a name="input_enable_database"></a> [enable\_database](#input\_enable\_database) | Enable Cloud SQL database deployment | `bool` | `true` | no |
 | <a name="input_enable_monitoring"></a> [enable\_monitoring](#input\_enable\_monitoring) | Enable Google Cloud Monitoring and Logging | `bool` | `true` | no |
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Enable Cloud NAT for outbound internet access | `bool` | `true` | no |
+| <a name="input_enable_valkey"></a> [enable\_valkey](#input\_enable\_valkey) | Enable Google Cloud Memorystore for Redis (Valkey-compatible) deployment | `bool` | `false` | no |
 | <a name="input_enable_vpc_connector"></a> [enable\_vpc\_connector](#input\_enable\_vpc\_connector) | Enable VPC Connector for Cloud Run to VPC communication | `bool` | `true` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_log_level"></a> [log\_level](#input\_log\_level) | Log level for applications | `string` | `"INFO"` | no |
@@ -241,6 +249,13 @@ No modules.
 | <a name="input_private_subnet_cidr"></a> [private\_subnet\_cidr](#input\_private\_subnet\_cidr) | CIDR block for the private subnet (must be /28 for VPC connector compatibility) | `string` | `"10.0.1.0/28"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID where resources will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The GCP region for resources | `string` | `"us-central1"` | no |
+| <a name="input_valkey_auth_enabled"></a> [valkey\_auth\_enabled](#input\_valkey\_auth\_enabled) | Whether AUTH is enabled for the Redis instance | `bool` | `true` | no |
+| <a name="input_valkey_maintenance_policy"></a> [valkey\_maintenance\_policy](#input\_valkey\_maintenance\_policy) | Maintenance policy for Redis instance | <pre>object({<br/>    weekly_maintenance_window = object({<br/>      day = string # MONDAY, TUESDAY, etc.<br/>      start_time = object({<br/>        hours   = number # 0-23<br/>        minutes = number # 0-59<br/>        seconds = number # 0-59<br/>        nanos   = number # 0-999999999<br/>      })<br/>    })<br/>  })</pre> | <pre>{<br/>  "weekly_maintenance_window": {<br/>    "day": "SUNDAY",<br/>    "start_time": {<br/>      "hours": 3,<br/>      "minutes": 0,<br/>      "nanos": 0,<br/>      "seconds": 0<br/>    }<br/>  }<br/>}</pre> | no |
+| <a name="input_valkey_memory_size_gb"></a> [valkey\_memory\_size\_gb](#input\_valkey\_memory\_size\_gb) | Redis instance memory size in GB | `number` | `1` | no |
+| <a name="input_valkey_redis_configs"></a> [valkey\_redis\_configs](#input\_valkey\_redis\_configs) | Redis configuration parameters | `map(string)` | <pre>{<br/>  "maxmemory-policy": "allkeys-lru"<br/>}</pre> | no |
+| <a name="input_valkey_redis_version"></a> [valkey\_redis\_version](#input\_valkey\_redis\_version) | Redis version for the instance | `string` | `"REDIS_7_0"` | no |
+| <a name="input_valkey_tier"></a> [valkey\_tier](#input\_valkey\_tier) | Service tier of the Redis instance (BASIC or STANDARD\_HA) | `string` | `"BASIC"` | no |
+| <a name="input_valkey_transit_encryption_mode"></a> [valkey\_transit\_encryption\_mode](#input\_valkey\_transit\_encryption\_mode) | TLS mode for Redis instance | `string` | `"SERVER_AUTH"` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR block for the VPC | `string` | `"10.0.0.0/16"` | no |
 
 ## Outputs
@@ -261,6 +276,13 @@ No modules.
 | <a name="output_private_subnet_id"></a> [private\_subnet\_id](#output\_private\_subnet\_id) | ID of the private subnet |
 | <a name="output_private_subnet_name"></a> [private\_subnet\_name](#output\_private\_subnet\_name) | Name of the private subnet |
 | <a name="output_resource_prefix"></a> [resource\_prefix](#output\_resource\_prefix) | Prefix used for naming resources |
+| <a name="output_valkey_auth_secret_name"></a> [valkey\_auth\_secret\_name](#output\_valkey\_auth\_secret\_name) | Name of the Secret Manager secret containing the Valkey auth string |
+| <a name="output_valkey_connection_secret_name"></a> [valkey\_connection\_secret\_name](#output\_valkey\_connection\_secret\_name) | Name of the Secret Manager secret containing the Valkey connection URL |
+| <a name="output_valkey_host"></a> [valkey\_host](#output\_valkey\_host) | Host IP of the Valkey/Redis instance |
+| <a name="output_valkey_instance_name"></a> [valkey\_instance\_name](#output\_valkey\_instance\_name) | Name of the Valkey/Redis instance |
+| <a name="output_valkey_memory_size_gb"></a> [valkey\_memory\_size\_gb](#output\_valkey\_memory\_size\_gb) | Memory size of the Valkey/Redis instance in GB |
+| <a name="output_valkey_port"></a> [valkey\_port](#output\_valkey\_port) | Port of the Valkey/Redis instance |
+| <a name="output_valkey_tier"></a> [valkey\_tier](#output\_valkey\_tier) | Service tier of the Valkey/Redis instance |
 | <a name="output_vpc_connector_id"></a> [vpc\_connector\_id](#output\_vpc\_connector\_id) | ID of the VPC connector (if enabled) |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | ID of the VPC network |
 | <a name="output_vpc_name"></a> [vpc\_name](#output\_vpc\_name) | Name of the VPC network |

--- a/iam.tf
+++ b/iam.tf
@@ -81,15 +81,16 @@ resource "google_project_iam_member" "app_logging_writer" {
 # Enable required APIs
 resource "google_project_service" "required_apis" {
   for_each = toset([
-    "run.googleapis.com",                 # Cloud Run
-    "secretmanager.googleapis.com",       # Secret Manager
-    "compute.googleapis.com",             # Compute Engine (for VPC)
-    "servicenetworking.googleapis.com",   # Service Networking (for Cloud SQL private IP)
-    "sqladmin.googleapis.com",            # Cloud SQL Admin API
-    "sql-component.googleapis.com",       # Cloud SQL Component API
-    "vpcaccess.googleapis.com",           # VPC Access (for VPC connector)
-    "iam.googleapis.com",                 # Identity and Access Management
-    "cloudresourcemanager.googleapis.com" # Cloud Resource Manager
+    "run.googleapis.com",                  # Cloud Run
+    "secretmanager.googleapis.com",        # Secret Manager
+    "compute.googleapis.com",              # Compute Engine (for VPC)
+    "servicenetworking.googleapis.com",    # Service Networking (for Cloud SQL private IP)
+    "sqladmin.googleapis.com",             # Cloud SQL Admin API
+    "sql-component.googleapis.com",        # Cloud SQL Component API
+    "vpcaccess.googleapis.com",            # VPC Access (for VPC connector)
+    "iam.googleapis.com",                  # Identity and Access Management
+    "cloudresourcemanager.googleapis.com", # Cloud Resource Manager
+    "redis.googleapis.com"                 # Cloud Memorystore for Redis (Valkey-compatible)
   ])
 
   project = var.project_id
@@ -109,6 +110,24 @@ resource "google_secret_manager_secret_iam_member" "app_config_files" {
   for_each  = var.app_config_files
   project   = var.project_id
   secret_id = google_secret_manager_secret.config_files[each.key].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.app.email}"
+}
+
+# Grant read access to Valkey connection secret
+resource "google_secret_manager_secret_iam_member" "app_valkey_connection" {
+  count     = var.enable_valkey ? 1 : 0
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.valkey_connection[0].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.app.email}"
+}
+
+# Grant read access to Valkey auth secret
+resource "google_secret_manager_secret_iam_member" "app_valkey_auth" {
+  count     = var.enable_valkey && var.valkey_auth_enabled ? 1 : 0
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.valkey_auth[0].id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.app.email}"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -60,4 +60,17 @@ locals {
 
   # Secret Manager reference for database password
   db_connection_secret = "${local.resource_prefix}-db-connection"
+
+  # Valkey/Redis configuration
+  valkey_instance_name     = "${local.resource_prefix}-valkey"
+  valkey_reserved_ip_range = "10.1.0.0/29" # Small range for Redis instance
+  valkey_connection_secret = "${local.resource_prefix}-valkey-connection"
+  valkey_auth_secret       = "${local.resource_prefix}-valkey-auth"
+
+  # Valkey connection string format
+  valkey_connection_string = var.enable_valkey ? (
+    var.valkey_auth_enabled ?
+    "valkey://default:${google_redis_instance.valkey[0].auth_string}@${google_redis_instance.valkey[0].host}:${google_redis_instance.valkey[0].port}" :
+    "valkey://${google_redis_instance.valkey[0].host}:${google_redis_instance.valkey[0].port}"
+  ) : ""
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -91,3 +91,39 @@ output "common_labels" {
   description = "Common labels applied to all resources"
   value       = local.common_labels
 }
+
+# Valkey/Redis Outputs (if enabled)
+output "valkey_instance_name" {
+  description = "Name of the Valkey/Redis instance"
+  value       = var.enable_valkey ? google_redis_instance.valkey[0].name : null
+}
+
+output "valkey_host" {
+  description = "Host IP of the Valkey/Redis instance"
+  value       = var.enable_valkey ? google_redis_instance.valkey[0].host : null
+}
+
+output "valkey_port" {
+  description = "Port of the Valkey/Redis instance"
+  value       = var.enable_valkey ? google_redis_instance.valkey[0].port : null
+}
+
+output "valkey_connection_secret_name" {
+  description = "Name of the Secret Manager secret containing the Valkey connection URL"
+  value       = var.enable_valkey ? google_secret_manager_secret.valkey_connection[0].secret_id : null
+}
+
+output "valkey_auth_secret_name" {
+  description = "Name of the Secret Manager secret containing the Valkey auth string"
+  value       = var.enable_valkey && var.valkey_auth_enabled ? google_secret_manager_secret.valkey_auth[0].secret_id : null
+}
+
+output "valkey_tier" {
+  description = "Service tier of the Valkey/Redis instance"
+  value       = var.enable_valkey ? google_redis_instance.valkey[0].tier : null
+}
+
+output "valkey_memory_size_gb" {
+  description = "Memory size of the Valkey/Redis instance in GB"
+  value       = var.enable_valkey ? google_redis_instance.valkey[0].memory_size_gb : null
+}

--- a/valkey.tf
+++ b/valkey.tf
@@ -1,0 +1,104 @@
+# Google Cloud Memorystore for Redis (Valkey-compatible)
+# Redis instances deployed in this module are compatible with Valkey clients
+
+resource "google_redis_instance" "valkey" {
+  count                   = var.enable_valkey ? 1 : 0
+  name                    = local.valkey_instance_name
+  tier                    = var.valkey_tier
+  memory_size_gb          = var.valkey_memory_size_gb
+  region                  = var.region
+  project                 = var.project_id
+  location_id             = "${var.region}-a"
+  alternative_location_id = var.valkey_tier == "STANDARD_HA" ? "${var.region}-b" : null
+
+  authorized_network = google_compute_network.main.id
+  redis_version      = var.valkey_redis_version
+  display_name       = "${local.resource_prefix} Valkey/Redis Instance"
+  reserved_ip_range  = local.valkey_reserved_ip_range
+
+  # Security configuration
+  auth_enabled            = var.valkey_auth_enabled
+  transit_encryption_mode = var.valkey_transit_encryption_mode
+
+  # Configuration parameters
+  redis_configs = var.valkey_redis_configs
+
+  # Maintenance policy
+  maintenance_policy {
+    weekly_maintenance_window {
+      day = var.valkey_maintenance_policy.weekly_maintenance_window.day
+      start_time {
+        hours   = var.valkey_maintenance_policy.weekly_maintenance_window.start_time.hours
+        minutes = var.valkey_maintenance_policy.weekly_maintenance_window.start_time.minutes
+        seconds = var.valkey_maintenance_policy.weekly_maintenance_window.start_time.seconds
+        nanos   = var.valkey_maintenance_policy.weekly_maintenance_window.start_time.nanos
+      }
+    }
+  }
+
+  labels = merge(local.common_labels, {
+    service_type     = "valkey"
+    redis_compatible = "true"
+  })
+
+  depends_on = [
+    google_project_service.required_apis,
+    google_compute_network.main
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  timeouts {
+    create = "20m"
+    update = "20m"
+    delete = "20m"
+  }
+}
+
+# Store Valkey/Redis connection details in Secret Manager
+resource "google_secret_manager_secret" "valkey_connection" {
+  count     = var.enable_valkey ? 1 : 0
+  secret_id = local.valkey_connection_secret
+  project   = var.project_id
+
+  labels = merge(local.common_labels, {
+    service_type = "valkey"
+  })
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required_apis]
+}
+
+resource "google_secret_manager_secret_version" "valkey_connection" {
+  count       = var.enable_valkey ? 1 : 0
+  secret      = google_secret_manager_secret.valkey_connection[0].id
+  secret_data = local.valkey_connection_string
+}
+
+# Store Valkey/Redis auth string in Secret Manager (if auth is enabled)
+resource "google_secret_manager_secret" "valkey_auth" {
+  count     = var.enable_valkey && var.valkey_auth_enabled ? 1 : 0
+  secret_id = local.valkey_auth_secret
+  project   = var.project_id
+
+  labels = merge(local.common_labels, {
+    service_type = "valkey"
+  })
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required_apis]
+}
+
+resource "google_secret_manager_secret_version" "valkey_auth" {
+  count       = var.enable_valkey && var.valkey_auth_enabled ? 1 : 0
+  secret      = google_secret_manager_secret.valkey_auth[0].id
+  secret_data = google_redis_instance.valkey[0].auth_string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -97,6 +97,89 @@ variable "database_ssl_mode" {
   }
 }
 
+# Valkey/Redis Configuration
+variable "enable_valkey" {
+  description = "Enable Google Cloud Memorystore for Redis (Valkey-compatible) deployment"
+  type        = bool
+  default     = false
+}
+
+variable "valkey_memory_size_gb" {
+  description = "Redis instance memory size in GB"
+  type        = number
+  default     = 1
+}
+
+variable "valkey_tier" {
+  description = "Service tier of the Redis instance (BASIC or STANDARD_HA)"
+  type        = string
+  default     = "BASIC"
+  validation {
+    condition     = contains(["BASIC", "STANDARD_HA"], var.valkey_tier)
+    error_message = "Valkey tier must be either BASIC or STANDARD_HA."
+  }
+}
+
+variable "valkey_redis_version" {
+  description = "Redis version for the instance"
+  type        = string
+  default     = "REDIS_7_0"
+  validation {
+    condition     = contains(["REDIS_6_X", "REDIS_7_0"], var.valkey_redis_version)
+    error_message = "Redis version must be either REDIS_6_X or REDIS_7_0."
+  }
+}
+
+variable "valkey_auth_enabled" {
+  description = "Whether AUTH is enabled for the Redis instance"
+  type        = bool
+  default     = true
+}
+
+variable "valkey_transit_encryption_mode" {
+  description = "TLS mode for Redis instance"
+  type        = string
+  default     = "SERVER_AUTH"
+  validation {
+    condition     = contains(["DISABLED", "SERVER_AUTH"], var.valkey_transit_encryption_mode)
+    error_message = "Transit encryption mode must be either DISABLED or SERVER_AUTH."
+  }
+}
+
+variable "valkey_redis_configs" {
+  description = "Redis configuration parameters"
+  type        = map(string)
+  default = {
+    maxmemory-policy = "allkeys-lru"
+  }
+}
+
+variable "valkey_maintenance_policy" {
+  description = "Maintenance policy for Redis instance"
+  type = object({
+    weekly_maintenance_window = object({
+      day = string # MONDAY, TUESDAY, etc.
+      start_time = object({
+        hours   = number # 0-23
+        minutes = number # 0-59
+        seconds = number # 0-59
+        nanos   = number # 0-999999999
+      })
+    })
+  })
+  default = {
+    weekly_maintenance_window = {
+      day = "SUNDAY"
+      start_time = {
+        hours   = 3
+        minutes = 0
+        seconds = 0
+        nanos   = 0
+      }
+    }
+  }
+}
+
 # Application Configuration
 variable "app_image" {
   description = "Container image for the hrafnar application (without tag)"


### PR DESCRIPTION
- Add comprehensive Valkey/Redis configuration variables
- Create valkey.tf with Google Cloud Memorystore for Redis resources
- Configure VPC integration with reserved IP range for Redis instance
- Add security features: auth, TLS encryption, maintenance policies
- Provide VALKEY_URL and REDIS_URL environment variables to Cloud Run
- Store connection details and auth strings in Secret Manager
- Add proper IAM permissions for Cloud Run to access Valkey secrets
- Include comprehensive outputs for monitoring and integration
- Support both BASIC and STANDARD_HA tiers with configurable memory

Enables Python applications to connect using valkey:// DSN format.