### PR TITLE
replace VPC connector with superior direct VPC egress

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,21 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.0
+    rev: 9a790d2bbf52124eecb5a71a4bab4884804ffa2a # v1.100.0
     hooks:
       - id: terraform_fmt
+        args:
+          - --hook-config=--tf-path=tofu
       - id: terraform_validate
+        args:
+          - --hook-config=--tf-path=tofu
       - id: terraform_docs
         args:
           - --args=--config=.terraform-docs.yml
+          - --hook-config=--tf-path=tofu
       - id: terraform_tflint
         args:
           - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
+          - --hook-config=--tf-path=tofu
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -21,12 +27,3 @@ repos:
         args: ['--maxkb=100']
       - id: check-merge-conflict
       - id: detect-private-key
-
-  - repo: https://github.com/terraform-docs/terraform-docs
-    rev: "cf462c5da36feb66051cf0a6f1124594ed9adc7c" # v0.20.0
-    hooks:
-      - name: "terraform-docs"
-        id: terraform-docs-go
-        args: ["markdown", "table", "--output-file", "README.md"] #, "./terraform/modules/argocd"]
-        files: .*\.tf$
-        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,12 @@ repos:
         args: ['--maxkb=100']
       - id: check-merge-conflict
       - id: detect-private-key
+
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: "cf462c5da36feb66051cf0a6f1124594ed9adc7c" # v0.20.0
+    hooks:
+      - name: "terraform-docs"
+        id: terraform-docs-go
+        args: ["markdown", "table", "--output-file", "README.md"] #, "./terraform/modules/argocd"]
+        files: .*\.tf$
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -216,7 +216,6 @@ No modules.
 | [google_storage_bucket_iam_member.hrafner_app_storage_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_object.storage_folders](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_hmac_key.hrafner_storage_hmac](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_hmac_key) | resource |
-| [google_vpc_access_connector.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vpc_access_connector) | resource |
 | [random_id.network_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_password.db_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 
@@ -252,12 +251,11 @@ No modules.
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Enable Cloud NAT for outbound internet access | `bool` | `true` | no |
 | <a name="input_enable_storage"></a> [enable\_storage](#input\_enable\_storage) | Enable Cloud Storage bucket for the application | `bool` | `false` | no |
 | <a name="input_enable_valkey"></a> [enable\_valkey](#input\_enable\_valkey) | Enable Google Cloud Memorystore for Redis (Valkey-compatible) deployment | `bool` | `false` | no |
-| <a name="input_enable_vpc_connector"></a> [enable\_vpc\_connector](#input\_enable\_vpc\_connector) | Enable VPC Connector for Cloud Run to VPC communication | `bool` | `true` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_log_level"></a> [log\_level](#input\_log\_level) | Log level for applications | `string` | `"INFO"` | no |
 | <a name="input_mcp_servers"></a> [mcp\_servers](#input\_mcp\_servers) | MCP server configurations | <pre>map(object({<br/>    url         = string<br/>    api_key     = optional(string)<br/>    description = string<br/>  }))</pre> | `{}` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for resource naming | `string` | n/a | yes |
-| <a name="input_private_subnet_cidr"></a> [private\_subnet\_cidr](#input\_private\_subnet\_cidr) | CIDR block for the private subnet (must be /28 for VPC connector compatibility) | `string` | `"10.0.1.0/28"` | no |
+| <a name="input_private_subnet_cidr"></a> [private\_subnet\_cidr](#input\_private\_subnet\_cidr) | CIDR block for the private subnet | `string` | `"10.0.0.0/24"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID where resources will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The GCP region for resources | `string` | `"us-central1"` | no |
 | <a name="input_storage_app_role"></a> [storage\_app\_role](#input\_storage\_app\_role) | IAM role for the application to access the storage bucket | `string` | `"roles/storage.objectAdmin"` | no |
@@ -310,7 +308,6 @@ No modules.
 | <a name="output_valkey_memory_size_gb"></a> [valkey\_memory\_size\_gb](#output\_valkey\_memory\_size\_gb) | Memory size of the Valkey/Redis instance in GB |
 | <a name="output_valkey_port"></a> [valkey\_port](#output\_valkey\_port) | Port of the Valkey/Redis instance |
 | <a name="output_valkey_tier"></a> [valkey\_tier](#output\_valkey\_tier) | Service tier of the Valkey/Redis instance |
-| <a name="output_vpc_connector_id"></a> [vpc\_connector\_id](#output\_vpc\_connector\_id) | ID of the VPC connector (if enabled) |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | ID of the VPC network |
 | <a name="output_vpc_name"></a> [vpc\_name](#output\_vpc\_name) | Name of the VPC network |
 <!-- END_TF_DOCS -->

--- a/cloud-run.tf
+++ b/cloud-run.tf
@@ -81,7 +81,7 @@ resource "google_cloud_run_service" "main_app" {
         dynamic "env" {
           for_each = var.enable_database ? [1] : []
           content {
-            name = "DATABASE_URL"
+            name = "HRAFNAR_STORAGE_PERSISTENT_DATABASE_DSN"
             value_from {
               secret_key_ref {
                 name = local.db_connection_secret

--- a/database.tf
+++ b/database.tf
@@ -5,6 +5,11 @@ resource "random_password" "db_password" {
   special = true
 }
 
+locals {
+  # necessary until https://github.com/openteams-ai/hrafnar/issues/59 is resolved
+  url_encoded_db_pwd = var.enable_database ? urlencode(random_password.db_password[0].result) : ""
+}
+
 # Cloud SQL PostgreSQL instance
 resource "google_sql_database_instance" "main" {
   count            = var.enable_database ? 1 : 0

--- a/database.tf
+++ b/database.tf
@@ -5,11 +5,6 @@ resource "random_password" "db_password" {
   special = true
 }
 
-locals {
-  # necessary until https://github.com/openteams-ai/hrafnar/issues/59 is resolved
-  url_encoded_db_pwd = var.enable_database ? urlencode(random_password.db_password[0].result) : ""
-}
-
 # Cloud SQL PostgreSQL instance
 resource "google_sql_database_instance" "main" {
   count            = var.enable_database ? 1 : 0

--- a/examples/dev/README.md
+++ b/examples/dev/README.md
@@ -109,6 +109,7 @@ module "hrafnar_gcp_deploy" {
 | <a name="input_cloudflare_zone_id"></a> [cloudflare\_zone\_id](#input\_cloudflare\_zone\_id) | Cloudflare zone ID (required if enable\_cloudflare\_dns is true) | `string` | `""` | no |
 | <a name="input_enable_cloudflare_dns"></a> [enable\_cloudflare\_dns](#input\_enable\_cloudflare\_dns) | Enable Cloudflare DNS management for development | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment (e.g., 'prod') | `string` | `"test"` | no |
+| <a name="input_hrafnar_models"></a> [hrafnar\_models](#input\_hrafnar\_models) | List of AI models available to Hrafnar | `list(string)` | <pre>[<br/>  "openai/gpt-4",<br/>  "anthropic/claude-3.5-sonnet"<br/>]</pre> | no |
 | <a name="input_mcp_servers"></a> [mcp\_servers](#input\_mcp\_servers) | MCP server configurations for development | <pre>map(object({<br/>    url         = string<br/>    api_key     = optional(string)<br/>    description = string<br/>  }))</pre> | <pre>{<br/>  "filesystem": {<br/>    "description": "Local filesystem MCP server for development",<br/>    "url": "http://localhost:3001"<br/>  }<br/>}</pre> | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for resource names | `string` | `"hrafnar-dev"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID for development environment | `string` | n/a | yes |

--- a/examples/dev/README.md
+++ b/examples/dev/README.md
@@ -103,7 +103,6 @@ module "hrafnar_gcp_deploy" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ai_api_keys"></a> [ai\_api\_keys](#input\_ai\_api\_keys) | Map of AI API keys (e.g., OPENAI\_API\_KEY, ANTHROPIC\_API\_KEY) | `map(string)` | `{}` | no |
-| <a name="input_app_image"></a> [app\_image](#input\_app\_image) | Container image for the hrafnar application | `string` | `"gcr.io/my-project/hrafnar:dev"` | no |
 | <a name="input_app_subdomain"></a> [app\_subdomain](#input\_app\_subdomain) | Subdomain for application access (e.g., 'app' for app.example.com) | `string` | `"app"` | no |
 | <a name="input_base_domain"></a> [base\_domain](#input\_base\_domain) | Base domain name (e.g., 'example.com') | `string` | `""` | no |
 | <a name="input_cloudflare_api_token"></a> [cloudflare\_api\_token](#input\_cloudflare\_api\_token) | Cloudflare API token (required if enable\_cloudflare\_dns is true) | `string` | `""` | no |

--- a/examples/dev/README.md
+++ b/examples/dev/README.md
@@ -121,5 +121,6 @@ module "hrafnar_gcp_deploy" {
 | <a name="output_app_domain"></a> [app\_domain](#output\_app\_domain) | Development app domain (if DNS enabled) |
 | <a name="output_database_connection_name"></a> [database\_connection\_name](#output\_database\_connection\_name) | Development database connection name |
 | <a name="output_hrafnar_app_url"></a> [hrafnar\_app\_url](#output\_hrafnar\_app\_url) | URL of the hrafnar application in development |
+| <a name="output_hrafnar_auth_password"></a> [hrafnar\_auth\_password](#output\_hrafnar\_auth\_password) | The authentication password for Hrafnar |
 | <a name="output_vpc_name"></a> [vpc\_name](#output\_vpc\_name) | Development VPC network name |
 <!-- END_TF_DOCS -->

--- a/examples/dev/README.md
+++ b/examples/dev/README.md
@@ -103,11 +103,13 @@ module "hrafnar_gcp_deploy" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ai_api_keys"></a> [ai\_api\_keys](#input\_ai\_api\_keys) | Map of AI API keys (e.g., OPENAI\_API\_KEY, ANTHROPIC\_API\_KEY) | `map(string)` | `{}` | no |
+| <a name="input_app_image_tag"></a> [app\_image\_tag](#input\_app\_image\_tag) | Tag for the Hrafnar application image | `string` | `"0.1.0.dev295-gf0b1471"` | no |
 | <a name="input_app_subdomain"></a> [app\_subdomain](#input\_app\_subdomain) | Subdomain for application access (e.g., 'app' for app.example.com) | `string` | `"app"` | no |
 | <a name="input_base_domain"></a> [base\_domain](#input\_base\_domain) | Base domain name (e.g., 'example.com') | `string` | `""` | no |
 | <a name="input_cloudflare_api_token"></a> [cloudflare\_api\_token](#input\_cloudflare\_api\_token) | Cloudflare API token (required if enable\_cloudflare\_dns is true) | `string` | `""` | no |
 | <a name="input_cloudflare_zone_id"></a> [cloudflare\_zone\_id](#input\_cloudflare\_zone\_id) | Cloudflare zone ID (required if enable\_cloudflare\_dns is true) | `string` | `""` | no |
 | <a name="input_enable_cloudflare_dns"></a> [enable\_cloudflare\_dns](#input\_enable\_cloudflare\_dns) | Enable Cloudflare DNS management for development | `bool` | `false` | no |
+| <a name="input_enable_database"></a> [enable\_database](#input\_enable\_database) | Enable persistent database (Cloud SQL) | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment (e.g., 'prod') | `string` | `"test"` | no |
 | <a name="input_hrafnar_models"></a> [hrafnar\_models](#input\_hrafnar\_models) | List of AI models available to Hrafnar | `list(string)` | <pre>[<br/>  "openai/gpt-4",<br/>  "anthropic/claude-3.5-sonnet"<br/>]</pre> | no |
 | <a name="input_mcp_servers"></a> [mcp\_servers](#input\_mcp\_servers) | MCP server configurations for development | <pre>map(object({<br/>    url         = string<br/>    api_key     = optional(string)<br/>    description = string<br/>  }))</pre> | <pre>{<br/>  "filesystem": {<br/>    "description": "Local filesystem MCP server for development",<br/>    "url": "http://localhost:3001"<br/>  }<br/>}</pre> | no |

--- a/examples/dev/main.tf
+++ b/examples/dev/main.tf
@@ -33,7 +33,7 @@ module "hrafnar_deploy" {
   name_prefix = var.name_prefix
   # For quay.io images, use Artifact Registry remote repository
   # See docs/ARTIFACT_REGISTRY_SETUP.md for one-time setup instructions
-  app_image     = "${var.region}-docker.pkg.dev/${var.project_id}/quay-remote/openteams/hrafnar"
+  app_image     = "${var.region}-docker.pkg.dev/${var.project_id}/quay-remote/reiemp/hrafnar"
   app_image_tag = "0.1.0.dev295-gf0b1471"
 
   # Production configuration
@@ -69,6 +69,7 @@ module "hrafnar_deploy" {
         password = random_password.hrafnar_auth_password.result
       }
     })
+    HRAFNAR_MODELS = jsonencode(var.hrafnar_models)
   }
 
   # Cloudflare DNS integration

--- a/examples/dev/main.tf
+++ b/examples/dev/main.tf
@@ -64,8 +64,8 @@ module "hrafnar_deploy" {
     HRAFNAR_SERVER_PORT                     = "8080"
     HRAFNAR_STORAGE_PERSISTENT_DATABASE_DSN = "sqlite:////var/hrafnar/state.db"
     HRAFNAR_AUTHENTICATION_METHOD = jsonencode({
-      cls      = "hrafnar.serve.DummyBasicAuth"
-      password = random_password.hrafnar_auth_password.result
+      cls_or_fn = "hrafnar.serve.DummyBasicAuth"
+      password  = random_password.hrafnar_auth_password.result
     })
   }
 

--- a/examples/dev/main.tf
+++ b/examples/dev/main.tf
@@ -34,7 +34,7 @@ module "hrafnar_deploy" {
   # For quay.io images, use Artifact Registry remote repository
   # See docs/ARTIFACT_REGISTRY_SETUP.md for one-time setup instructions
   app_image     = "${var.region}-docker.pkg.dev/${var.project_id}/quay-remote/reiemp/hrafnar"
-  app_image_tag = "0.1.0.dev295-gf0b1471"
+  app_image_tag = var.app_image_tag
 
   # Production configuration
   region     = var.region
@@ -60,9 +60,8 @@ module "hrafnar_deploy" {
 
   # Application environment variables
   app_env_vars = {
-    HRAFNAR_SERVER_HOSTNAME                 = "0.0.0.0"
-    HRAFNAR_SERVER_PORT                     = "8080"
-    HRAFNAR_STORAGE_PERSISTENT_DATABASE_DSN = "sqlite:////var/hrafnar/state.db"
+    HRAFNAR_SERVER_HOSTNAME = "0.0.0.0"
+    HRAFNAR_SERVER_PORT     = "8080"
     HRAFNAR_AUTHENTICATION_METHOD = jsonencode({
       cls_or_fn = "hrafnar.serve.DummyBasicAuth"
       params = {
@@ -79,7 +78,7 @@ module "hrafnar_deploy" {
   app_subdomain         = var.app_subdomain
 
   # Infrastructure settings
-  enable_database    = false
+  enable_database    = var.enable_database
   enable_nat_gateway = true
   enable_monitoring  = true
   log_level          = "INFO"

--- a/examples/dev/main.tf
+++ b/examples/dev/main.tf
@@ -55,6 +55,9 @@ module "hrafnar_deploy" {
   # AI API keys
   ai_api_keys = var.ai_api_keys
 
+  # MCP server configuration
+  mcp_servers = var.mcp_servers
+
   # Application environment variables
   app_env_vars = {
     HRAFNAR_SERVER_HOSTNAME                 = "0.0.0.0"
@@ -67,17 +70,16 @@ module "hrafnar_deploy" {
   }
 
   # Cloudflare DNS integration
-  enable_cloudflare_dns = false
+  enable_cloudflare_dns = var.enable_cloudflare_dns
   cloudflare_zone_id    = var.cloudflare_zone_id
   base_domain           = var.base_domain
   app_subdomain         = var.app_subdomain
 
   # Infrastructure settings
-  enable_database      = false
-  enable_nat_gateway   = true
-  enable_vpc_connector = true
-  enable_monitoring    = true
-  log_level            = "INFO"
+  enable_database    = false
+  enable_nat_gateway = true
+  enable_monitoring  = true
+  log_level          = "INFO"
 
   # Environment and labeling
   labels = {

--- a/examples/dev/main.tf
+++ b/examples/dev/main.tf
@@ -33,8 +33,8 @@ module "hrafnar_deploy" {
   name_prefix = var.name_prefix
   # For quay.io images, use Artifact Registry remote repository
   # See docs/ARTIFACT_REGISTRY_SETUP.md for one-time setup instructions
-  app_image     = "${var.region}-docker.pkg.dev/${var.project_id}/quay-remote/reiemp/hrafnar"
-  app_image_tag = "latest"
+  app_image     = "${var.region}-docker.pkg.dev/${var.project_id}/quay-remote/openteams/hrafnar"
+  app_image_tag = "0.1.0.dev295-gf0b1471"
 
   # Production configuration
   region     = var.region
@@ -65,7 +65,9 @@ module "hrafnar_deploy" {
     HRAFNAR_STORAGE_PERSISTENT_DATABASE_DSN = "sqlite:////var/hrafnar/state.db"
     HRAFNAR_AUTHENTICATION_METHOD = jsonencode({
       cls_or_fn = "hrafnar.serve.DummyBasicAuth"
-      password  = random_password.hrafnar_auth_password.result
+      params = {
+        password = random_password.hrafnar_auth_password.result
+      }
     })
   }
 
@@ -87,4 +89,10 @@ module "hrafnar_deploy" {
     project     = "test-${var.name_prefix}-openteams-ai"
     managed_by  = "terraform"
   }
+}
+
+output "hrafnar_auth_password" {
+  description = "The authentication password for Hrafnar"
+  value       = random_password.hrafnar_auth_password.result
+  sensitive   = true
 }

--- a/examples/dev/terraform.tfvars.example
+++ b/examples/dev/terraform.tfvars.example
@@ -1,31 +1,25 @@
 # Example terraform.tfvars for development environment
 # Copy this file to terraform.tfvars and fill in your values
 
-# Required variables
-project_id = "my-gcp-project-dev"
-app_image  = "gcr.io/my-project/hrafnar:dev"
+# Replace with your GCP Project ID
+project_id = "your-gcp-project-id"
 
-# AI API keys (keep these secure!)
+# A unique prefix for your resources, e.g., "hrafnar-prod"
+name_prefix = "your-name-prefix"
+
+# App image tag
+app_image_tag = "0.1.0.dev295-gf0b1471"
+
+# Enable persistent database
+enable_database = true
+
+# Optional: Add your AI API keys here. They will be stored securely in Secret Manager.
 ai_api_keys = {
-  OPENAI_API_KEY    = "sk-..."
-  ANTHROPIC_API_KEY = "sk-ant-..."
+  OPENROUTER_API_KEY = "sk-or-v1-..."
+  # Add other keys as needed
 }
 
-# Optional: MCP servers for development
-mcp_servers = {
-  filesystem = {
-    url         = "http://localhost:3001"
-    description = "Local filesystem MCP server"
-  }
-  git = {
-    url         = "http://localhost:3002"
-    api_key     = "dev-key-123"
-    description = "Local git MCP server"
-  }
-}
-
-# Optional: Cloudflare DNS (uncomment to enable)
-# enable_cloudflare_dns = true
-# cloudflare_api_token  = "your-cloudflare-token"
-# cloudflare_zone_id    = "your-zone-id"
-# base_domain          = "dev.example.com"
+cloudflare_api_token = "your-cloudflare-token"
+cloudflare_zone_id   = "your-zone-id"
+base_domain          = "your-domain.com"
+app_subdomain        = "your-subdomain"

--- a/examples/dev/variables.tf
+++ b/examples/dev/variables.tf
@@ -3,12 +3,6 @@ variable "project_id" {
   type        = string
 }
 
-variable "app_image" {
-  description = "Container image for the hrafnar application"
-  type        = string
-  default     = "gcr.io/my-project/hrafnar:dev"
-}
-
 variable "ai_api_keys" {
   description = "Map of AI API keys (e.g., OPENAI_API_KEY, ANTHROPIC_API_KEY)"
   type        = map(string)

--- a/examples/dev/variables.tf
+++ b/examples/dev/variables.tf
@@ -75,3 +75,12 @@ variable "app_subdomain" {
   type        = string
   default     = "app"
 }
+
+variable "hrafnar_models" {
+  description = "List of AI models available to Hrafnar"
+  type        = list(string)
+  default = [
+    "openai/gpt-4",
+    "anthropic/claude-3.5-sonnet"
+  ]
+}

--- a/examples/dev/variables.tf
+++ b/examples/dev/variables.tf
@@ -3,6 +3,18 @@ variable "project_id" {
   type        = string
 }
 
+variable "app_image_tag" {
+  description = "Tag for the Hrafnar application image"
+  type        = string
+  default     = "0.1.0.dev295-gf0b1471"
+}
+
+variable "enable_database" {
+  description = "Enable persistent database (Cloud SQL)"
+  type        = bool
+  default     = false
+}
+
 variable "ai_api_keys" {
   description = "Map of AI API keys (e.g., OPENAI_API_KEY, ANTHROPIC_API_KEY)"
   type        = map(string)

--- a/locals.tf
+++ b/locals.tf
@@ -33,9 +33,6 @@ locals {
   private_subnet_name = "${local.resource_prefix}-subnet-${random_id.network_suffix.hex}"
   nat_gateway_name    = "${local.resource_prefix}-nat-${random_id.network_suffix.hex}"
   router_name         = "${local.resource_prefix}-router-${random_id.network_suffix.hex}"
-  # VPC connector name must be <= 25 chars and match ^[a-z][-a-z0-9]{0,23}[a-z0-9]$
-  # Add random suffix to avoid naming collisions
-  vpc_connector_name = length("${local.resource_prefix}-conn-${random_id.network_suffix.hex}") <= 25 ? "${local.resource_prefix}-conn-${random_id.network_suffix.hex}" : "${substr(local.resource_prefix, 0, 11)}-conn-${random_id.network_suffix.hex}"
 
   # Cloud Run service names
   main_app_service_name = "${local.resource_prefix}-app"

--- a/networking.tf
+++ b/networking.tf
@@ -43,26 +43,6 @@ resource "google_compute_router_nat" "main" {
   }
 }
 
-# VPC Connector for Cloud Run to VPC communication
-resource "google_vpc_access_connector" "main" {
-  count   = var.enable_vpc_connector ? 1 : 0
-  name    = local.vpc_connector_name
-  region  = var.region
-  project = var.project_id
-
-  subnet {
-    name       = google_compute_subnetwork.private.name
-    project_id = var.project_id
-  }
-
-  # Minimum instances for the connector
-  min_instances = 2
-  max_instances = 3
-
-  # Machine type for the connector
-  machine_type = "e2-micro"
-}
-
 # Firewall rule to allow health checks for Cloud Run
 resource "google_compute_firewall" "allow_health_checks" {
   name    = "${local.resource_prefix}-allow-health-checks"

--- a/outputs.tf
+++ b/outputs.tf
@@ -53,11 +53,6 @@ output "private_subnet_name" {
   value       = google_compute_subnetwork.private.name
 }
 
-output "vpc_connector_id" {
-  description = "ID of the VPC connector (if enabled)"
-  value       = var.enable_vpc_connector ? google_vpc_access_connector.main[0].id : null
-}
-
 # Service Account Outputs
 output "hrafnar_app_service_account_email" {
   description = "Email of the hrafnar application service account"

--- a/secrets.tf
+++ b/secrets.tf
@@ -67,7 +67,7 @@ resource "google_secret_manager_secret" "db_connection" {
 resource "google_secret_manager_secret_version" "db_connection" {
   count       = var.enable_database ? 1 : 0
   secret      = google_secret_manager_secret.db_connection[0].id
-  secret_data = "postgresql+psycopg://${local.database_user}:${local.url_encoded_db_pwd}@${google_sql_database_instance.main[0].private_ip_address}:5432/${local.database_name}"
+  secret_data = "postgresql+psycopg://${urlencode(local.database_user)}:${urlencode(random_password.db_password[0].result)}@${google_sql_database_instance.main[0].private_ip_address}:5432/${local.database_name}"
 }
 
 # Secret Manager secrets for config files

--- a/secrets.tf
+++ b/secrets.tf
@@ -67,7 +67,7 @@ resource "google_secret_manager_secret" "db_connection" {
 resource "google_secret_manager_secret_version" "db_connection" {
   count       = var.enable_database ? 1 : 0
   secret      = google_secret_manager_secret.db_connection[0].id
-  secret_data = "postgresql+psycopg://${local.database_user}:${random_password.db_password[0].result}@${google_sql_database_instance.main[0].private_ip_address}:5432/${local.database_name}"
+  secret_data = "postgresql+psycopg://${local.database_user}:${local.url_encoded_db_pwd}@${google_sql_database_instance.main[0].private_ip_address}:5432/${local.database_name}"
 }
 
 # Secret Manager secrets for config files

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -21,9 +21,15 @@ func TestDevEnvironmentDeployment(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/dev",
 		Vars: map[string]interface{}{
+			// Required root/example variables to avoid "No value for required variable" errors
+			"project_id":    "test-project",
+			"region":        "us-central1",
+			// Test-scoped variables
 			"name_prefix":   namePrefix,
 			"app_subdomain": namePrefix,
 			"environment":   "integration-test",
+			// Keep database disabled for this test to match assertions
+			"enable_database": false,
 		},
 		// Retry configuration for handling transient errors
 		RetryableTerraformErrors: map[string]string{

--- a/variables.tf
+++ b/variables.tf
@@ -27,9 +27,20 @@ variable "vpc_cidr" {
 }
 
 variable "private_subnet_cidr" {
-  description = "CIDR block for the private subnet (must be /28 for VPC connector compatibility)"
+  description = "CIDR block for the private subnet"
   type        = string
-  default     = "10.0.1.0/28"
+  default     = "10.0.0.0/24"
+  validation {
+    condition     = can(regex("^[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}/[0-9]{1,2}$", var.private_subnet_cidr))
+    error_message = "Invalid CIDR format."
+  }
+  
+  # Ensure CIDR is /26 or larger
+  # https://cloud.google.com/run/docs/configuring/vpc-direct-vpc#scale_down
+  validation {
+    condition     = can(regex("^[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}/[0-9]{1,2}$", var.private_subnet_cidr)) && (tonumber(regex("[0-9]{1,2}$", var.private_subnet_cidr)) <= 26)
+    error_message = "CIDR range must be /26 or larger (required by direct VPC egress)."
+  }
 }
 
 variable "enable_nat_gateway" {

--- a/variables.tf
+++ b/variables.tf
@@ -426,12 +426,6 @@ variable "log_level" {
 
 # Security Configuration
 
-variable "enable_vpc_connector" {
-  description = "Enable VPC Connector for Cloud Run to VPC communication"
-  type        = bool
-  default     = true
-}
-
 # Resource Tags
 variable "labels" {
   description = "Labels to apply to all resources"

--- a/variables.tf
+++ b/variables.tf
@@ -34,9 +34,8 @@ variable "private_subnet_cidr" {
     condition     = can(regex("^[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}/[0-9]{1,2}$", var.private_subnet_cidr))
     error_message = "Invalid CIDR format."
   }
-  
-  # Ensure CIDR is /26 or larger
-  # https://cloud.google.com/run/docs/configuring/vpc-direct-vpc#scale_down
+
+  # Ensure CIDR is /26 or larger (See https://cloud.google.com/run/docs/configuring/vpc-direct-vpc#scale_down for more info)
   validation {
     condition     = can(regex("^[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}/[0-9]{1,2}$", var.private_subnet_cidr)) && (tonumber(regex("[0-9]{1,2}$", var.private_subnet_cidr)) <= 26)
     error_message = "CIDR range must be /26 or larger (required by direct VPC egress)."


### PR DESCRIPTION
I was catching up on the project and I noticed Direct VPC egress seems to be recommended over Serverless VPC Access connectors so I made the change.  It scales to 0 and offers other benefits as seen in the table.

<img width="1748" height="1263" alt="image" src="https://github.com/user-attachments/assets/a86651d9-758e-4704-a575-0bed8636f32c" />

# Relevant Docs
- https://cloud.google.com/run/docs/configuring/connecting-vpc
- https://cloud.google.com/run/docs/securing/private-networking#to-vpc